### PR TITLE
FEATURE: add ordering to the CMS menu system 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,35 @@
 # SilverStripe Grouped CMS Menu
 
-This module allows you to group CMS menu items into nested lists which expand
-when hovered over. This is useful when there are so many CMS menu items that
-screen space becomes an issue.
+This module allows you to group CMS menu items into nested lists which expand when hovered over. This is useful when 
+there are so many CMS menu items that screen space becomes an issue.
 
 Previous versions are available through the appropriate branch.
 
 ## Basic Usage
 
-In order to group CMS menu items together, define your menu groups in your config.yml file. 
-example below, CMSMain (Pages) and AssetAdmin (Files &amp; Images) are grouped
-together under a "Content" heading:
+In order to group CMS menu items together, define your menu groups in a `config.yml` file.
 
-```
+In the example below, CMSMain (Pages) and AssetAdmin (Files &amp; Images) are grouped
+together under a "Content" heading.
+
+```yml
 LeftAndMain:
   menu_groups:
     Content:
       - CMSPagesController
+      - AssetAdmin
+```
+Each grouped menu will be ordered by the way you configure your YML. If you do not add an item to a grouping, they will 
+appear at the bottom of the menu. You may also choose to "group" items by themselves to make sure that they are ordered 
+correctly in your menu.
+
+```yml
+LeftAndMain:
+  menu_groups:
+    CMSPagesController: []
+    CMSSettingsController: []
+    Other:
+      - ReportAdmin
       - AssetAdmin
 ```
 

--- a/_config/groupedcmsmenu.yml
+++ b/_config/groupedcmsmenu.yml
@@ -1,3 +1,7 @@
+---
+Name: grouped-cms-menu
+After: 'framework/*', 'cms/*'
+---
 LeftAndMain:
   extensions:
     - GroupedCmsMenu

--- a/code/GroupedCmsMenu.php
+++ b/code/GroupedCmsMenu.php
@@ -2,19 +2,24 @@
 /**
  * Decorates left and main to provide a grouped/nested CMS menu.
  *
- * @package silverstripe-grouped-cms-menu
+ * @package grouped-cms-menu
  */
 class GroupedCmsMenu extends Extension {
 
+	/**
+	 * @var array
+	 */
 	private static $menu_groups = array();
 
+	/**
+	 * Require in CSS which we need for the menu
+	 */
 	public function init() {
-		//Requirements::javascript('grouped-cms-menu/javascript/GroupedCmsMenu.js');
 		Requirements::css('grouped-cms-menu/css/GroupedCmsMenu.css');
 	}
 
 	/**
-	 * @return DataObjectSet
+	 * @return ArrayList
 	 */
 	public function GroupedMainMenu() {
 		$items  = $this->owner->MainMenu();
@@ -22,23 +27,36 @@ class GroupedCmsMenu extends Extension {
 		$groupSettings = Config::inst()->get('LeftAndMain', 'menu_groups');
 		$groups = array();
 
+		$position = 0;
 		foreach ($groupSettings as $key => $menuItems) {
-			foreach ($menuItems as $menuItem ) {
-				$groups[$menuItem] = $key ;
+			$groups[$key] = array(
+				'Code' => $key,
+				'Position' => $position
+			);
+			$position++;
+			if (count($menuItems)) {
+				foreach ($menuItems as $menuItem ) {
+					$groups[$menuItem] = array(
+						'Code' => $key,
+						'Position' => $position
+					);
+					$position++;
+				}
 			}
 		}
 
 		foreach ($items as $item) {
 			$code = $item->Code->XML();
 			if (array_key_exists($code, $groups)) {
-				$item->Group = $groups[$code];
+				$item->Group = $groups[$code]['Code'];
+				$item->Position = $groups[$code]['Position'];
 			} else {
 				$item->Group = $code;
+				$item->Position = 9999;
 			}
 		}
 
-		foreach (GroupedList::create($items)->groupBy('Group') as $group => $children) {
-
+		foreach (GroupedList::create($items->sort('Position'))->groupBy('Group') as $group => $children) {
 			if (count($children) > 1) {
 				$active = false;
 
@@ -47,11 +65,12 @@ class GroupedCmsMenu extends Extension {
 				}
 
 				$result->push(ArrayData::create(array(
-					'Title'       	=> $group,
-					'Code'    		=> DBField::create_field('Text', str_replace(' ', '_', $group)),
-					'Link'        	=> $children->First()->Link,
-					'LinkingMode' 	=> $active ? 'current' : '',
-					'Children'    	=> $children
+					'Title' => $group,
+					'Code' => DBField::create_field('Text', str_replace(' ', '_', $group)),
+					'Link' => $children->First()->Link,
+					'LinkingMode' => $active ? 'current' : '',
+					'Position' => $position,
+					'Children' => $children->sort('Position')
 				)));
 			} else {
 				$result->push($children->First());

--- a/javascript/GroupedCmsMenu.js
+++ b/javascript/GroupedCmsMenu.js
@@ -1,7 +1,0 @@
-;(function ($) {
-
-	$.entwine('ss.groupedcmsmenu', function($){
-		
-	});
-
-})(jQuery);


### PR DESCRIPTION
Ordering in YML is preserved in the CMS without having to set menu_priority on each menu item.
I've also cleaned up the docs and deleted some unused javascript :smile: 

Let me know if you can see a better / easier way to do this.

This code is backwards compatible, but does slightly change the expectations in the API so should probably be a 2.2 release