### PR TITLE
Icons, Sort order & UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,30 @@ LeftAndMain:
       - CMSPagesController
       - AssetAdmin
 ```
-Each grouped menu will be ordered by the way you configure your YML. If you do not add an item to a grouping, they will 
-appear at the bottom of the menu. You may also choose to "group" items by themselves to make sure that they are ordered 
-correctly in your menu.
+
+## Sort order
+
+The items in each grouped menu will follow the order you set in your YML. The groups 
+themselves will be inserted in the menu with a priority of 0, with other menu items 
+appearing above or below depending on their existing priority.
+You can change the priority of a menu group like this:
 
 ```yml
 LeftAndMain:
   menu_groups:
-    CMSPagesController: []
-    CMSSettingsController: []
+    Other:
+      priority: -500
+      - ReportAdmin
+      - SecurityAdmin
+```
+
+Or you can "group" items by themselves to make any menu item follow the order you set in your configuration:
+
+```yml
+LeftAndMain:
+  menu_groups:
+    CMSPagesController:
+      - CMSPagesController
     Other:
       - ReportAdmin
       - AssetAdmin

--- a/README.md
+++ b/README.md
@@ -33,6 +33,20 @@ LeftAndMain:
       - AssetAdmin
 ```
 
+## Group icons
+
+You can add a CSS class to groups for the purpose of adding an icon. The class name will be prefixed with 'icon-'.
+In the example below the same icon used for the Pages menu item will be used for the Content group.
+
+```yml
+LeftAndMain:
+  menu_groups:
+    Content:
+      icon: 'cmspagescontroller'
+      - CMSPagesController
+      - AssetAdmin
+```
+
 ## Translating group labels
 
 A group label may be translated by providing a translation key as below (using

--- a/code/GroupedCmsMenu.php
+++ b/code/GroupedCmsMenu.php
@@ -12,10 +12,11 @@ class GroupedCmsMenu extends Extension {
 	private static $menu_groups = array();
 
 	/**
-	 * Require in CSS which we need for the menu
+	 * Require in CSS & JS which we need for the menu
 	 */
 	public function init() {
 		Requirements::css('grouped-cms-menu/css/GroupedCmsMenu.css');
+		Requirements::javascript('grouped-cms-menu/javascript/GroupedCmsMenu.js');
 	}
 
 	/**

--- a/code/GroupedCmsMenu.php
+++ b/code/GroupedCmsMenu.php
@@ -64,12 +64,13 @@ class GroupedCmsMenu extends Extension {
 				foreach ($children as $child) {
 					if ($child->LinkingMode == 'current') $active = true;
 				}
-
+				$icon = array_key_exists('icon', $groupSettings[$group]) ? $groupSettings[$group]['icon'] : false;
 				$code = str_replace(' ', '_', $group);
 				$result->push(ArrayData::create(array(
 					'Title' => _t('GroupedCmsMenuLabel.'.$code, $group),
 					'Code' => DBField::create_field('Text', $code),
 					'Link' => $children->First()->Link,
+					'Icon' => $icon,
 					'LinkingMode' => $active ? 'current' : '',
 					'Position' => $position,
 					'Children' => $children->sort('Position')

--- a/css/GroupedCmsMenu.css
+++ b/css/GroupedCmsMenu.css
@@ -6,7 +6,6 @@
 
 .cms-menu-list li.children > a {
 	padding-right: 30px;
-	padding-left: 17px;
 }
 
 .cms-menu-list li.children ul li a {
@@ -20,6 +19,6 @@
 	line-height: 32px;
 }
 
-.cms-menu-list li a .grouped-cms-menu.text {
-	margin-left: 0;
+.cms-menu-list li a .no-icon.text {
+	margin-left: 8px;
 }

--- a/javascript/GroupedCmsMenu.js
+++ b/javascript/GroupedCmsMenu.js
@@ -1,0 +1,18 @@
+(function($) {
+	
+	$.entwine('ss', function($){
+		
+		/**
+		 * When clicking a group heading, open/close the list instead of 
+		 * loading its first child
+		 */
+		$('.cms-menu-list > li.children > a').entwine({
+			onclick: function(e) {
+				this.getMenuItem().toggle();
+				e.preventDefault();
+			}
+		});
+		
+	});
+	
+}(jQuery));

--- a/templates/LeftAndMain_Menu.ss
+++ b/templates/LeftAndMain_Menu.ss
@@ -26,7 +26,12 @@
 			<li class="$LinkingMode $FirstLast<% if $Children %> children <% end_if %><% if $LinkingMode == 'link' %><% else %>opened<% end_if %>" id="Menu-$Code" title="$Title.ATT">
 				<a href="$Link" $AttributesHTML>
 					<% if $Children %>
-						<span class="grouped-cms-menu text">$Title</span>
+						<% if $Icon %>
+							<span class="icon icon-16 icon-$Icon">&nbsp;</span>
+							<span class="text">$Title</span>
+						<% else %>
+							<span class="no-icon text">$Title</span>
+						<% end_if %>
 					<% else %>
 						<span class="icon icon-16 icon-{$Code.LowerCase}">&nbsp;</span>
 						<span class="text">$Title</span>


### PR DESCRIPTION
Easiest to explain with a graphic:

![grouped-menu](https://cloud.githubusercontent.com/assets/1079425/11449469/9c3355c4-952b-11e5-95f5-db1cdf1df79e.png)

Icon support is important for appearance when the menu is minimised (which it frequently is in 3.2), and respecting the `$menu_priority` of ungrouped menu items makes this module play nicer with others. Additionally, not auto-loading the first menu item when you click a group menu item should result in lower instances of muttered swear words.