### PR TITLE
FIX Icons and sticky toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ langcode:
 
 ## Requirements
 
-* SilverStripe 3.0+
+* SilverStripe 3.2+ (See other branches for compatibility with older versions)
 
 ## Project Links
 

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
 		"email": "marcus@silverstripe.com.au"
 	}],
 	"require": {
-		"silverstripe/framework": "~3.1",
-		"silverstripe/cms": "~3.1"
+		"silverstripe/framework": "^3.2",
+		"silverstripe/cms": "^3.2"
 	},
 	"extra": {
 		"installer-name": "grouped-cms-menu",

--- a/templates/LeftAndMain_Menu.ss
+++ b/templates/LeftAndMain_Menu.ss
@@ -8,10 +8,10 @@
 		</div>
 
 		<div class="cms-login-status">
-			<a href="Security/logout" class="logout-link" title="<% _t('LeftAndMain_Menu.ss.LOGOUT','Log out') %>"><% _t('LeftAndMain_Menu_ss.LOGOUT','Log out') %></a>
+			<a href="$LogoutURL" class="logout-link font-icon-logout" title="<%t LeftAndMain_Menu_ss.LOGOUT 'Log out' %>"></a>
 			<% with $CurrentMember %>
 				<span>
-					<% _t('LeftAndMain_Menu_ss.Hello','Hi') %>
+					<%t LeftAndMain_Menu_ss.Hello 'Hi' %>
 					<a href="{$AbsoluteBaseURL}admin/myprofile" class="profile-link">
 						<% if $FirstName && $Surname %>$FirstName $Surname<% else_if $FirstName %>$FirstName<% else %>$Email<% end_if %>
 					</a>
@@ -55,6 +55,8 @@
 	</div>
 
 	<div class="cms-panel-toggle south">
+		<button class="sticky-toggle" type="button" title="Sticky nav">Sticky nav</button>
+		<span class="sticky-status-indicator">auto</span>
 		<a class="toggle-expand" href="#"><span>&raquo;</span></a>
 		<a class="toggle-collapse" href="#"><span>&laquo;</span></a>
 	</div>


### PR DESCRIPTION
Added missing markup required for sticky toggle in SS 3.2 and CSS class required for logout icon in SS 3.3. This is compatible with 3.2 and 3.3 markup (unless it changes before release) but not compatible with 3.1 so I've bumped the SS version requirement to 3.2.