### PR TITLE
FIX prevent text from overlapping icon when menu is collapsed

### DIFF
--- a/css/GroupedCmsMenu.css
+++ b/css/GroupedCmsMenu.css
@@ -22,3 +22,7 @@
 .cms-menu-list li a .no-icon.text {
 	margin-left: 8px;
 }
+
+.cms-menu-list.collapsed li.children ul li a span.text {
+	margin-left: 30px;
+}


### PR DESCRIPTION
When menu is collapsed in SS3.3 the text in the grouped menu overlaps the icon. Just needs to be pushed across a bit more.