### PR TITLE
Removed CMS requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,7 @@
 		"email": "marcus@silverstripe.com.au"
 	}],
 	"require": {
-		"silverstripe/framework": "^3.2",
-		"silverstripe/cms": "^3.2"
+		"silverstripe/framework": "^3.2"
 	},
 	"extra": {
 		"installer-name": "grouped-cms-menu",


### PR DESCRIPTION
The module works fine without the CMS. This allows projects which do not need the CMS to still use this module, without the CMS being installed.