### PR TITLE
Fix opened arrow icon positioning

### DIFF
--- a/client/dist/css/GroupedCmsMenu.css
+++ b/client/dist/css/GroupedCmsMenu.css
@@ -21,3 +21,7 @@
     background-image: none !important;
     top: 35% !important;
 }
+
+.cms-menu__list li.current > a .toggle-children .toggle-children-icon{
+    height: 8px;
+}

--- a/client/dist/css/GroupedCmsMenu.css
+++ b/client/dist/css/GroupedCmsMenu.css
@@ -22,6 +22,6 @@
     top: 35% !important;
 }
 
-.cms-menu__list li.current > a .toggle-children .toggle-children-icon{
+.cms-menu__list li.current > a .toggle-children .toggle-children-icon {
     height: 8px;
 }


### PR DESCRIPTION
If the group menu item is clicked in the CMS menu part of the arrow icon is cut off. This fix will adjust this.

**Before:**
![Screenshot 2024-03-08 at 15 03 33](https://github.com/symbiote/silverstripe-grouped-cms-menu/assets/1586761/df45763d-2bd0-485f-9e5c-da19b2b46b16)

**After:**
![Screenshot 2024-03-08 at 15 09 06](https://github.com/symbiote/silverstripe-grouped-cms-menu/assets/1586761/c94b828a-ca37-4333-95d6-39f102efb6e6)
