### PR TITLE
SilverStripe 6 Compatible and Support for FontAwesome Icons 

### DIFF
--- a/_config/groupedcmsmenu.yml
+++ b/_config/groupedcmsmenu.yml
@@ -4,5 +4,7 @@ After: 'framework/*, cms/*'
 ---
 
 SilverStripe\Admin\LeftAndMain:
+  extra_requirements_css:
+    - vendor/symbiote/silverstripe-grouped-cms-menu/client/dist/css/GroupedCmsMenu.css
   extensions:
     - Symbiote\GroupedCmsMenu\Admin\GroupedCmsMenu

--- a/client/dist/css/GroupedCmsMenu.css
+++ b/client/dist/css/GroupedCmsMenu.css
@@ -21,3 +21,50 @@
     background-image: none !important;
     top: 35% !important;
 }
+
+.cms-menu__list li ul.group {
+    margin: 0 0 0 15px;
+    padding: 0;
+}
+
+.cms-menu__list li ul.group,
+.cms-menu__list li ul.group li {
+    list-style: none;
+}
+
+.cms-menu__list li ul.group li a {
+    min-height: 35px;
+}
+
+.cms-menu__list li ul.group li a .text {
+    padding-left: 8px;
+}
+
+.cms-menu__list li a .toggle-children-icon,
+.cms-menu__list li a .toggle-children .toggle-children-icon {
+    background-image: none !important;
+    top: 35% !important;
+}
+
+.cms-menu__list li ul.group li {
+    height: 0px;
+}
+
+.cms-menu__list li:hover ul.group li,
+.cms-menu__list li.opened ul.group li {
+    min-height: 35px;
+    height: unset;
+}
+
+.cms-menu__list li.opened ul.group li a {
+    background: none;
+}
+.cms-menu__list li.opened ul.group li:hover,
+.cms-menu__list li.opened ul.group li.current {
+    background: #d8e4eb;
+}
+
+.cms-menu__list li{
+    background: #d8e4eb;
+    background: #005a93;
+}

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         }
     ],
     "require": {
-        "silverstripe/admin": "^1.3 || ^2.0"
+        "silverstripe/framework": "^6.0",
+        "silverstripe/admin": "^3.0"
     },
     "extra": {
         "expose": [

--- a/src/Admin/GroupedCmsMenu.php
+++ b/src/Admin/GroupedCmsMenu.php
@@ -3,22 +3,22 @@
 namespace Symbiote\GroupedCmsMenu\Admin;
 
 use SilverStripe\Admin\LeftAndMain;
-use SilverStripe\Admin\LeftAndMainExtension;
 use SilverStripe\Core\Convert;
+use SilverStripe\Core\Extension;
 use SilverStripe\View\Requirements;
-use SilverStripe\ORM\ArrayList;
-use SilverStripe\ORM\GroupedList;
-use SilverStripe\View\ArrayData;
+use SilverStripe\Model\List\ArrayList;
+use SilverStripe\Model\List\GroupedList;
+use SilverStripe\Model\ArrayData;
 use SilverStripe\ORM\FieldType\DBField;
 use SilverStripe\ORM\FieldType\DBText;
-use SilverStripe\ORM\SS_List;
+use SilverStripe\Model\List\SS_List;
 
 /**
  * Decorates {@link LeftAndMain} to provide a grouped/nested CMS menu.
  *
  * @package grouped-cms-menu
  */
-class GroupedCmsMenu extends LeftAndMainExtension
+class GroupedCmsMenu extends Extension
 {
 
     /**
@@ -171,7 +171,7 @@ class GroupedCmsMenu extends LeftAndMainExtension
             return $class::create()->config()->get('menu_icon_class');
         }
 
-        return 'font-icon-' . (!empty($groupSettings[$group]['icon']) ? $groupSettings[$group]['icon'] : '');
+        return (!empty($groupSettings[$group]['icon']) ? $groupSettings[$group]['icon'] : '');
     }
 
     /**


### PR DESCRIPTION
We updated the Module 

It now works with SilverStripe 6.
We also added the feature to use FontAwesome Icons instead only font-icons because we use it a lot in our projects.

so you need to use the complete CSS-Classname of that Icon inside the YML config.



 